### PR TITLE
feat: allow pulling queries from `system.profile`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const { deferred } = require('promise-callbacks');
 const assert = require('assert');
-const _ = require('underscore');
+const _ = require('lodash');
 
 const fingerprint = require('./fingerprint');
 
@@ -13,6 +13,8 @@ const INDEXED_PLANS = ['IXSCAN', 'IDHACK'];
  * @property {string}  ns             The namespace the operation targets
  * @property {?string} planSummary    The query plan for the operation
  * @property {boolean} waitingForLock Whether the operation is waiting for a lock
+ * @property {boolean} indexed        Whether the operation is using an index
+ * @property {boolean} collscan       Whether the operation is using a collection scan
  *
  * @see https://docs.mongodb.com/manual/reference/command/currentOp/#currentop-output-fields
  */
@@ -27,18 +29,25 @@ class MongoSlowQueryChecker {
    * @param {Object} options Options to use to create the Mongo slow query
    *    checker.
    *    @property {Object} options.db The Mongo DB reference.
+   *    @property {Boolean} options.useProfiling Whether to use system.profile;
+   *       if not, we will only look at currently running queries. Profiling needs
+   *       to be enabled for this to work. This parameter is optional, and it defaults
+   *       to `false`.
    *    @property {Number} options.queryThreshold The time threshold to use to
    *       classify a Mongo query as slow, given in seconds. This parameter is
    *       optional, and if not provided it defaults to five seconds.
+   *    @property {Boolean} options.reportAllCollscans If true and using system.profile,
+   *       all queries using a COLLSCAN will be reported as slow queries, even if they
+   *       didn't exceed `options.queryThreshold`. This parameter is optional, and it
+   *       defaults to `false`.
    */
   constructor(options) {
     assert(options.db, 'Must provide a valid DB reference');
 
     this.db = options.db;
-    this.queryThreshold = 5;
-    if (options.queryThreshold) {
-      this.queryThreshold = options.queryThreshold;
-    }
+    this.useProfiling = options.useProfiling || false;
+    this.queryThreshold = options.queryThreshold || 5;
+    this.reportAllCollscans = options.reportAllCollscans || false;
   }
 
   /**
@@ -57,6 +66,37 @@ class MongoSlowQueryChecker {
    * ```
    */
   async get() {
+    const ops = this.useProfiling
+      ? await this.getFromSystemProfile()
+      : await this.getCurrentlyRunningQueries();
+
+    return this.processOps(ops);
+  }
+
+  /**
+   * Get relevant (slow/COLLSCAN) queries from the `system.profile` table, ensuring we don't
+   * repeatedly return the same queries in consecutive runs.
+   *
+   * Note that this only returns queries longer than both this.queryThreshold and the mongod
+   * servers slow query threshold.
+   */
+  async getFromSystemProfile() {
+    this.profile = this.profile || (await this.db.connect()).collection('system.profile');
+
+    const conditions = [{ millis: { $gte: this.queryThreshold * 1000 } }];
+    if (this.reportAllCollscans) conditions.push({ planSummary: { $regex: /COLLSCAN/ } });
+    const profileQuery = { $or: conditions, ns: { $not: /system.profile/ } };
+    if (this.lastTimestampInSystemProfile) {
+      profileQuery.ts = { $gt: this.lastTimestampInSystemProfile };
+    }
+
+    const queries = await this.profile.find(profileQuery).toArray();
+
+    this.lastTimestampInSystemProfile = _.max(_.map(queries, (q) => q.ts));
+    return queries;
+  }
+
+  async getCurrentlyRunningQueries() {
     const isMongoJS = typeof this.db.__getConnection === 'function';
     const command = {
       currentOp: true,
@@ -80,28 +120,30 @@ class MongoSlowQueryChecker {
       // Assume this.db is a reference to the 'admin' db
       ops = await this.db.runCommand(command);
     }
-    return this.processOps(ops);
+    return ops && ops.inprog;
   }
 
   /**
    * Returns an array of ops given the result of a db command.
    *
-   * @param      {Object}  ops     The result of an op query.
+   * @param      {Object}  queries     List of ops/queries.
    * @return     {Array}   An array of formatted mongo ops with details about their run time..
    */
-  processOps(ops) {
-    const inprog = ops && ops.inprog;
-    if (!inprog || !inprog.length) {
-      // Short circuit early.
+  processOps(queries) {
+    if (!queries) {
       return [];
     }
 
-    const processed = _.map(inprog, (op) => {
+    const processed = _.map(queries, (op) => {
+      const filter =
+        op.query || op.command.q || op.command.filter || op.command.query || op.command.pipeline;
+
       return {
         query: op,
-        fingerprint: fingerprint(op.query),
+        fingerprint: fingerprint(filter),
         collection: op.ns ? op.ns.replace(/.*\./, '') : '(no collection)',
         indexed: op.planSummary && this.isIndexed(op),
+        collscan: op.planSummary && this.isCollscan(op),
         waitingForLock: op.waitingForLock,
         appName: op.appName,
       };
@@ -117,6 +159,16 @@ class MongoSlowQueryChecker {
    */
   isIndexed(op) {
     return INDEXED_PLANS.some((p) => op.planSummary.indexOf(p) !== -1);
+  }
+
+  /**
+   * Given an operation with a planSummary, determines whether or not it's doing a collscan.
+   *
+   * @param {CurrentOp} op
+   * @return {boolean} whether or not the given operation is doing a collscan
+   */
+  isCollscan(op) {
+    return op.planSummary.indexOf('COLLSCAN') !== -1;
   }
 }
 


### PR DESCRIPTION
#### Changes Made

* Created a 2nd method capable of pulling problematic queries from `system.profile` (instead of just from currently running queries)
* Added option to use that method instead of the original one
* Added option to add queries requiring a COLLSCAN to the results
* Added a flag to the result objects indicating if the queries require a COLSCAN

#### Potential Risks
I have not completely checked the accuracy of the output (which relies on the exact semantics of the `system.profile.planSummary` property. There may be operations requiring COLLSCAN in sub-queries (e.g. aggregations) going unnoticed.

#### Test Plan
- [x] Start the mongo server with `--profile 2`. Run the service and check the output.

#### Checklist
- [ ] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
